### PR TITLE
Åpner opp for å spesifisere alternativ HttpClient

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 group = "no.nav.helsearbeidsgiver"
-version = "0.3.1"
+version = "0.3.2"
 
 plugins {
     kotlin("jvm")

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjonKlient.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjonKlient.kt
@@ -11,13 +11,14 @@ import java.net.URL
 
 class ArbeidsgiverNotifikasjonKlient(
     url: String,
+    httpClient: HttpClient = HttpClient(OkHttp),
     private val getAccessToken: () -> String
 ) {
     internal val logger = LoggerFactory.getLogger(this::class.java)
 
     private val graphQLClient = GraphQLKtorClient(
         url = URL(url),
-        httpClient = createHttpClient()
+        httpClient = httpClient
     )
 
     internal suspend fun <T : Any> execute(query: GraphQLClientRequest<T>): GraphQLClientResponse<T> =
@@ -25,6 +26,3 @@ class ArbeidsgiverNotifikasjonKlient(
             bearerAuth(getAccessToken())
         }
 }
-
-internal fun createHttpClient(): HttpClient =
-    HttpClient(OkHttp)

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/arbeidsgivernotifikasjon/MockArbeidsgiverNotifikasjonKlient.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/arbeidsgivernotifikasjon/MockArbeidsgiverNotifikasjonKlient.kt
@@ -7,10 +7,6 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
-import io.mockk.every
-import io.mockk.mockkStatic
-import io.mockk.unmockkStatic
-import kotlin.reflect.KFunction
 
 fun mockArbeidsgiverNotifikasjonKlient(content: String): ArbeidsgiverNotifikasjonKlient {
     val mockEngine = MockEngine {
@@ -20,20 +16,5 @@ fun mockArbeidsgiverNotifikasjonKlient(content: String): ArbeidsgiverNotifikasjo
             headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
         )
     }
-
-    val mockHttpClient = HttpClient(mockEngine)
-
-    return mockFn(::createHttpClient) {
-        every { createHttpClient() } returns mockHttpClient
-        ArbeidsgiverNotifikasjonKlient("https://url") { "fake token" }
-    }
-}
-
-private fun <T> mockFn(fn: KFunction<*>, block: () -> T): T {
-    mockkStatic(fn)
-    return try {
-        block()
-    } finally {
-        unmockkStatic(fn)
-    }
+    return ArbeidsgiverNotifikasjonKlient("https://url", HttpClient(mockEngine)) { "fake token" }
 }


### PR DESCRIPTION
- Lar deg bruke ktors MockEngine med response for å kunne lettere skrive tester.
- Dersom HttpClient ikke er oppgitt brukes den innebygde