### PR TITLE
Fjern valgfri http-klient

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,8 +68,8 @@ dependencies {
     val slf4jVersion: String by project
 
     implementation("com.expediagroup:graphql-kotlin-ktor-client:$graphQLKotlinVersion")
+    implementation("io.ktor:ktor-client-apache5:$ktorVersion")
     implementation("io.ktor:ktor-client-core:$ktorVersion")
-    implementation("io.ktor:ktor-client-okhttp:$ktorVersion")
     implementation("org.slf4j:slf4j-api:$slf4jVersion")
 
     testImplementation(kotlin("test"))

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjonKlient.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjonKlient.kt
@@ -4,21 +4,20 @@ import com.expediagroup.graphql.client.ktor.GraphQLKtorClient
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import com.expediagroup.graphql.client.types.GraphQLClientResponse
 import io.ktor.client.HttpClient
-import io.ktor.client.engine.okhttp.OkHttp
+import io.ktor.client.engine.apache5.Apache5
 import io.ktor.client.request.bearerAuth
 import org.slf4j.LoggerFactory
 import java.net.URL
 
 class ArbeidsgiverNotifikasjonKlient(
     url: String,
-    httpClient: HttpClient = HttpClient(OkHttp),
     private val getAccessToken: () -> String
 ) {
     internal val logger = LoggerFactory.getLogger(this::class.java)
 
     private val graphQLClient = GraphQLKtorClient(
         url = URL(url),
-        httpClient = httpClient
+        httpClient = createHttpClient()
     )
 
     internal suspend fun <T : Any> execute(query: GraphQLClientRequest<T>): GraphQLClientResponse<T> =
@@ -26,3 +25,6 @@ class ArbeidsgiverNotifikasjonKlient(
             bearerAuth(getAccessToken())
         }
 }
+
+internal fun createHttpClient(): HttpClient =
+    HttpClient(Apache5)

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjonKlientTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjonKlientTest.kt
@@ -7,7 +7,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
-class ArbeidsgiverNotifikasjonKlientTest() {
+class ArbeidsgiverNotifikasjonKlientTest {
 
     @Test
     fun `Forventer gyldig respons fra whoami`() {

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/arbeidsgivernotifikasjon/MockArbeidsgiverNotifikasjonKlient.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/arbeidsgivernotifikasjon/MockArbeidsgiverNotifikasjonKlient.kt
@@ -7,6 +7,10 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
+import io.mockk.every
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import kotlin.reflect.KFunction
 
 fun mockArbeidsgiverNotifikasjonKlient(content: String): ArbeidsgiverNotifikasjonKlient {
     val mockEngine = MockEngine {
@@ -16,5 +20,20 @@ fun mockArbeidsgiverNotifikasjonKlient(content: String): ArbeidsgiverNotifikasjo
             headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
         )
     }
-    return ArbeidsgiverNotifikasjonKlient("https://url", HttpClient(mockEngine)) { "fake token" }
+
+    val mockHttpClient = HttpClient(mockEngine)
+
+    return mockStatic(::createHttpClient) {
+        every { createHttpClient() } returns mockHttpClient
+        ArbeidsgiverNotifikasjonKlient("https://url") { "fake token" }
+    }
+}
+
+private fun <T> mockStatic(mockFn: KFunction<*>, block: () -> T): T {
+    mockkStatic(mockFn)
+    return try {
+        block()
+    } finally {
+        unmockkStatic(mockFn)
+    }
 }


### PR DESCRIPTION
Reverter en gammel, tvilsom endring: https://github.com/navikt/helsearbeidsgiver-arbeidsgiver-notifikasjon-klient/pull/5

NB: Denne må merges inn etter https://github.com/navikt/helsearbeidsgiver-arbeidsgiver-notifikasjon-klient/pull/6