### PR TITLE
Bytt sendevindu til NKS åpningstid for IM-oppgavevarsler til arbeidsgiver

### DIFF
--- a/src/main/kotlin/no/nav/helsearbeidsgiver/arbeidsgivernotifikasjon/Paaminnelse.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/arbeidsgivernotifikasjon/Paaminnelse.kt
@@ -31,7 +31,7 @@ fun Paaminnelse.tilPaaminnelseInput(): PaaminnelseInput =
                                 ),
                             tittel = tittel,
                             innhold = innhold,
-                            sendevindu = Sendevindu.LOEPENDE,
+                            sendevindu = Sendevindu.NKS_AAPNINGSTID,
                         ),
                 ),
             ),

--- a/src/main/resources/arbeidsgivernotifikasjon/OpprettNyOppgave.graphql
+++ b/src/main/resources/arbeidsgivernotifikasjon/OpprettNyOppgave.graphql
@@ -40,7 +40,7 @@ mutation OpprettNyOppgave(
                     tittel: $varslingTittel,
                     innhold: $varslingInnhold,
                     sendetidspunkt: {
-                        sendevindu: LOEPENDE
+                        sendevindu: NKS_AAPNINGSTID
                     },
                 }
             }


### PR DESCRIPTION
**Bakgrunn**
I dag sender vi varsler (både det første varselet og påminnelsen) løpende, det vil si så fort som mulig etter tidspunktet vi har definert. Dersom en oppgave blir opprettet på natten eller i helgen, så vil også varselet og påminnelsen kunne bli sendt ut på natten eller i helgen.

**Løsning**
Bytt sendevindu til NKS åpningstid for utsending av varsler (både det første varselet og påminnelsen).

Dette gjør vi for å øke sjansen for at de blir agert på av arbeidsgiver. Hypotesen er at et varsel som kommer i arbeidstid har større sjanse for å føre til en innsending enn et varsel som blir sendt ut på samme tidspunkt som oppgaven blir opprettet. Se Team Fager sin fullstendige definisjon av NKS_AAPNINGSTID-sendevindu [her](https://navikt.github.io/arbeidsgiver-notifikasjon-produsent-api/api.html#definition-Sendevindu).