### PR TITLE
Tillat opprettelse av sak uten lenke

### DIFF
--- a/src/main/kotlin/no/nav/helsearbeidsgiver/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjonKlient.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjonKlient.kt
@@ -49,7 +49,7 @@ class ArbeidsgiverNotifikasjonKlient(
         virksomhetsnummer: String,
         grupperingsid: String,
         merkelapp: String,
-        lenke: String,
+        lenke: String?,
         tittel: String,
         statusTekst: String?,
         tilleggsinfo: String? = null,

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjonKlientTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjonKlientTest.kt
@@ -31,6 +31,26 @@ class ArbeidsgiverNotifikasjonKlientTest : FunSpec({
             resultat shouldBe "269752"
         }
 
+        test("vellykket - ny sak uten lenke") {
+            val response = "responses/nySak/vellykket.json".readResource()
+            val arbeidsgiverNotifikasjonKlient = mockArbeidsgiverNotifikasjonKlient(response)
+
+            val resultat =
+                arbeidsgiverNotifikasjonKlient.opprettNySak(
+                    virksomhetsnummer = "mock virksomhetsnummer",
+                    grupperingsid = "mock grupperingsid",
+                    merkelapp = "mock merkelapp",
+                    lenke = null,
+                    tittel = "mock tittel",
+                    statusTekst = "mock statusTekst",
+                    tilleggsinfo = "mock tilleggsinfo",
+                    initiellStatus = SaksStatus.UNDER_BEHANDLING,
+                    hardDeleteOm = 10.days,
+                )
+
+            resultat shouldBe "269752"
+        }
+
         test("sak finnes fra før - ny sak") {
             val response = "responses/nySak/duplikatGrupperingsid.json".readResource()
             val arbeidsgiverNotifikasjonKlient = mockArbeidsgiverNotifikasjonKlient(response)


### PR DESCRIPTION
**Bakgrunn**
Vi ønsker å endre litt på strukturen til sakene og oppgavene våre i arbeidsgiverportalen, nå som flere ting enn inntektsmeldingen (f.eks. sykepengesøknad og vedtak om refusjon) på sikt skal inn i hver sak. Se https://nav-it.slack.com/archives/C02F7211DQ8/p1738756738622779

**Løsning**
Gjør lenke valgfritt ved opprettelse av nye saker.