### PR TITLE
Bump avhengigheter (Kotlin 2 og Ktor 3)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,10 +16,8 @@ jobs:
         with:
           java-version: 21
           distribution: temurin
-          cache: gradle
 
-      - name: Verify Gradle wrapper checksum
-        uses: gradle/wrapper-validation-action@v1
+      - uses: gradle/actions/setup-gradle@v4
 
       - name: Build with Gradle and Publish artifact
         run: ./gradlew build publish

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -12,10 +12,8 @@ jobs:
         with:
           java-version: 21
           distribution: temurin
-          cache: gradle
 
-      - name: Verify Gradle wrapper checksum
-        uses: gradle/wrapper-validation-action@v1
+      - uses: gradle/actions/setup-gradle@v4
 
       - name: Build and test with Gradle
         run: ./gradlew clean build test

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 
 kotlin {
     compilerOptions {
-        jvmTarget.set(JvmTarget.JVM_21)
+        jvmTarget = JvmTarget.JVM_21
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,17 +1,17 @@
 kotlin.code.style=official
 
 # Plugin and dependency versions
-graphQLKotlinVersion=7.1.1
+graphQLKotlinVersion=8.4.0
 
 # Plugin versions
-kotlinVersion=1.9.24
+kotlinVersion=2.0.21
 kotlinterVersion=4.3.0
 
 # Dependency versions
-coroutinesVersion=1.8.1
+coroutinesVersion=1.10.2
 kotestVersion=5.9.1
-ktorVersion=2.3.11
-logbackVersion=1.5.6
-mockkVersion=1.13.11
-slf4jVersion=2.0.13
+ktorVersion=3.1.2
+logbackVersion=1.5.18
+mockkVersion=1.14.0
+slf4jVersion=2.0.17
 utilsVersion=0.9.0


### PR DESCRIPTION
Går også over til Java 21. Dette, og bump til Kotlin 2 og Ktor 3, er de mest substansielle endringene.