### PR TITLE
Legg til retry og timeout

### DIFF
--- a/src/main/kotlin/no/nav/helsearbeidsgiver/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjonKlient.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjonKlient.kt
@@ -5,6 +5,8 @@ import com.expediagroup.graphql.client.types.GraphQLClientError
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.apache5.Apache5
+import io.ktor.client.plugins.HttpRequestRetry
+import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.request.bearerAuth
 import no.nav.helsearbeidsgiver.arbeidsgivernotifkasjon.graphql.generated.HardDeleteSak
 import no.nav.helsearbeidsgiver.arbeidsgivernotifkasjon.graphql.generated.HardDeleteSakByGrupperingsid
@@ -304,4 +306,21 @@ class ArbeidsgiverNotifikasjonKlient(
     }
 }
 
-internal fun createHttpClient(): HttpClient = HttpClient(Apache5)
+internal fun createHttpClient(): HttpClient =
+    HttpClient(Apache5) {
+        expectSuccess = true
+
+        install(HttpRequestRetry) {
+            retryOnException(
+                maxRetries = 5,
+                retryOnTimeout = true,
+            )
+            exponentialDelay()
+        }
+
+        install(HttpTimeout) {
+            connectTimeoutMillis = 500
+            requestTimeoutMillis = 500
+            socketTimeoutMillis = 500
+        }
+    }


### PR DESCRIPTION
Baserer timeout på at kallene stort sett bruker under 200 ms (se Grafana).

Eksponensiell delay og 5 retries fører til en god del ventetid, men disse kallene gjøres på slutten av flyten i Simba, så vi har ikke hastverk.

https://grafana.nav.cloud.nais.io/d/rZtfrreVz/simba-inntektsmelding?orgId=1&from=now-14d&to=now-7d&timezone=browser&var-env=000000021