### PR TITLE
Legg til mulighet for å endre sakens levetid ved statusendring

### DIFF
--- a/src/main/kotlin/no/nav/helsearbeidsgiver/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjonKlient.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjonKlient.kt
@@ -69,8 +69,7 @@ class ArbeidsgiverNotifikasjonKlient(
                     lenke = lenke,
                     initiellStatus = initiellStatus,
                     overstyrStatustekstMed = statusTekst,
-                    // https://en.wikipedia.org/wiki/ISO_8601#Durations
-                    hardDeleteOm = "P${hardDeleteOm.inWholeDays}D",
+                    hardDeleteOm = hardDeleteOm.tilDagerIso8601(),
                 ),
         ).also { loggInfo("Forsøker å opprette ny sak.") }
             .execute(
@@ -87,6 +86,7 @@ class ArbeidsgiverNotifikasjonKlient(
         statusTekst: String? = null,
         nyLenke: String? = null,
         tidspunkt: ISO8601DateTime? = null,
+        hardDeleteOm: Duration? = null,
     ) {
         loggInfo("Forsøker å sette ny status '$status' på sak med grupperingsid '$grupperingsid'.")
 
@@ -97,8 +97,9 @@ class ArbeidsgiverNotifikasjonKlient(
                     merkelapp = merkelapp,
                     nyStatus = status,
                     overstyrStatustekstMed = statusTekst,
-                    nyLenkeTilSak = nyLenke,
+                    nyLenke = nyLenke,
                     tidspunkt = tidspunkt,
+                    hardDeleteOm = hardDeleteOm?.tilDagerIso8601(),
                 ),
         ).execute(
             toResult = NyStatusSakByGrupperingsid.Result::nyStatusSakByGrupperingsid,
@@ -174,7 +175,12 @@ class ArbeidsgiverNotifikasjonKlient(
         loggInfo("Setter oppgave med eksternId '$eksternId' til utgått.")
 
         OppgaveUtgaattByEksternId(
-            variables = OppgaveUtgaattByEksternId.Variables(merkelapp = merkelapp, eksternId = eksternId, nyLenke = nyLenke),
+            variables =
+                OppgaveUtgaattByEksternId.Variables(
+                    merkelapp = merkelapp,
+                    eksternId = eksternId,
+                    nyLenke = nyLenke,
+                ),
         ).execute(
             toResult = OppgaveUtgaattByEksternId.Result::oppgaveUtgaattByEksternId,
             toSuccess = { it as? OppgaveUtgaattVellykket },
@@ -324,3 +330,6 @@ internal fun createHttpClient(): HttpClient =
             socketTimeoutMillis = 500
         }
     }
+
+/** [Les om ISO8601-durations](https://en.wikipedia.org/wiki/ISO_8601#Durations) */
+private fun Duration.tilDagerIso8601(): String = "P${inWholeDays}D"

--- a/src/main/resources/arbeidsgivernotifikasjon/NyStatusSakByGrupperingsid.graphql
+++ b/src/main/resources/arbeidsgivernotifikasjon/NyStatusSakByGrupperingsid.graphql
@@ -3,16 +3,23 @@ mutation NyStatusSakByGrupperingsid(
     $merkelapp: String!
     $nyStatus: SaksStatus!
     $overstyrStatustekstMed: String
-    $nyLenkeTilSak: String
+    $nyLenke: String
     $tidspunkt: ISO8601DateTime
+    $hardDeleteOm: ISO8601Duration
 ) {
     nyStatusSakByGrupperingsid(
         grupperingsid: $grupperingsid
         merkelapp: $merkelapp
         nyStatus: $nyStatus
         overstyrStatustekstMed: $overstyrStatustekstMed
-        nyLenkeTilSak: $nyLenkeTilSak
+        nyLenkeTilSak: $nyLenke
         tidspunkt: $tidspunkt
+        hardDelete: {
+            nyTid: {
+                om: $hardDeleteOm
+            },
+            strategi: OVERSKRIV
+        }
     ) {
         __typename
         ... on NyStatusSakVellykket {

--- a/src/main/resources/arbeidsgivernotifikasjon/Schema.graphql
+++ b/src/main/resources/arbeidsgivernotifikasjon/Schema.graphql
@@ -1098,52 +1098,49 @@ type Mutation {
         paaminnelse: PaaminnelseInput
     ): OppdaterKalenderavtaleResultat!
 
-    """
-    Markerer en notifikasjon som slettet (soft delete).
-
-    Notifikasjonen vil forsvinne helt for mottakeren: de vil ikke kunne se den på
-    noen som helst måte — som om notifikasjonen aldri eksisterte.
-
-    For dere (produsenter), så kan dere fortsatt se notifikasjonen i listen over deres notifikasjoner.
-
-    Eventuelle eksterne varsler (SMS, e-post) knyttet til notifikasjonen vil bli fortsatt bli sendt.
-
-    Advarsel: det er ikke mulig å angre på denne operasjonen.
-    """
     softDeleteNotifikasjon(id: ID!): SoftDeleteNotifikasjonResultat!
+    @deprecated(reason:
+    "All sletting er endret til å medføre hard delete. Denne mutation blir snart fjernet. bruk hardDeleteNotifikasjon(id) i stedet."
+    )
 
-    """
-    Se dokumentasjon for `softDeleteNotifikasjon(id)`.
-    """
     softDeleteNotifikasjonByEksternId(
-        """
-        Merkelappen som dere ga oss da dere opprettet notifikasjonen.
-        """
         merkelapp: String!,
-
-        """
-        ID-en som dere ga oss da dere opprettet notifikasjonen.
-        """
         eksternId: ID!
     ): SoftDeleteNotifikasjonResultat!
     @deprecated(reason:
-    "Using the type ID for `eksternId` can lead to unexpected behaviour. Use softDeleteNotifikasjonByEksternId_V2 instead."
+    "All sletting er endret til å medføre hard delete. Denne mutation blir snart fjernet. bruk hardDeleteNotifikasjonByEksternId_V2(merkelapp, eksternId) i stedet."
     )
 
-    """
-    Se dokumentasjon for `softDeleteNotifikasjon(id)`.
-    """
     softDeleteNotifikasjonByEksternId_V2(
-        """
-        Merkelappen som dere ga oss da dere opprettet notifikasjonen.
-        """
         merkelapp: String!,
-
-        """
-        ID-en som dere ga oss da dere opprettet notifikasjonen.
-        """
         eksternId: String!
     ): SoftDeleteNotifikasjonResultat!
+    @deprecated(reason:
+    "All sletting er endret til å medføre hard delete. Denne mutation blir snart fjernet. bruk hardDeleteNotifikasjonByEksternId_V2(merkelapp, eksternId) i stedet."
+    )
+
+    hardDeleteNotifikasjonByEksternId(
+        merkelapp: String!
+        eksternId: ID!
+    ): HardDeleteNotifikasjonResultat!
+    @deprecated(reason:
+    "Using the type ID for `eksternId` can lead to unexpected behaviour. Use hardDeleteNotifikasjonByEksternId_V2 instead."
+    )
+
+    softDeleteSak(
+        id: ID!
+    ): SoftDeleteSakResultat!
+    @deprecated(reason:
+    "All sletting er endret til å medføre hard delete. Denne mutation blir snart fjernet. bruk hardDeleteSak(id) i stedet."
+    )
+
+    softDeleteSakByGrupperingsid(
+        merkelapp: String!
+        grupperingsid: String!
+    ): SoftDeleteSakResultat!
+    @deprecated(reason:
+    "All sletting er endret til å medføre hard delete. Denne mutation blir snart fjernet. bruk hardDeleteSakByGrupperingsid(merkelapp, grupperingsid) i stedet."
+    )
 
     """
     Sletter en notifikasjon og tilhørende data helt fra databasen og kafka.
@@ -1163,24 +1160,6 @@ type Mutation {
     """
     Se dokumentasjon for `hardDeleteNotifikasjon(id)`.
     """
-    hardDeleteNotifikasjonByEksternId(
-        """
-        Merkelappen som dere ga oss da dere opprettet notifikasjonen.
-        """
-        merkelapp: String!
-
-        """
-        ID-en som dere ga oss da dere opprettet notifikasjonen.
-        """
-        eksternId: ID!
-    ): HardDeleteNotifikasjonResultat!
-    @deprecated(reason:
-    "Using the type ID for `eksternId` can lead to unexpected behaviour. Use hardDeleteNotifikasjonByEksternId_V2 instead."
-    )
-
-    """
-    Se dokumentasjon for `hardDeleteNotifikasjon(id)`.
-    """
     hardDeleteNotifikasjonByEksternId_V2(
         """
         Merkelappen som dere ga oss da dere opprettet notifikasjonen.
@@ -1192,37 +1171,6 @@ type Mutation {
         """
         eksternId: String!
     ): HardDeleteNotifikasjonResultat!
-
-    """
-    Markerer en sak som slettet (soft delete).
-
-    Sak vil forsvinne helt for mottakeren: de vil ikke kunne se den på
-    noen som helst måte — som om saken aldri eksisterte.
-
-    Advarsel: det er ikke mulig å angre på denne operasjonen.
-    Advarsel: ingen notifikasjoner blir slettet, selv om de har samme grupperingsid.
-    """
-    softDeleteSak(
-        """
-        ID-en som notifikasjolnen har. Den du fikk da du opprettet notifikasjonen.
-        """
-        id: ID!
-    ): SoftDeleteSakResultat!
-
-    """
-    Se dokumentasjon for `softDeleteSak(id)`.
-    """
-    softDeleteSakByGrupperingsid(
-        """
-        Merkelappen som dere ga oss da dere opprettet saken.
-        """
-        merkelapp: String!
-
-        """
-        ID-en som dere ga oss da dere opprettet saken.
-        """
-        grupperingsid: String!
-    ): SoftDeleteSakResultat!
 
     """
     Sletter en sak og tilhørende data helt fra databasen og kafka.
@@ -1248,8 +1196,6 @@ type Mutation {
         """
         grupperingsid: String!
     ): HardDeleteSakResultat!
-
-
 }
 
 union SoftDeleteNotifikasjonResultat =

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjonKlientTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjonKlientTest.kt
@@ -114,6 +114,7 @@ class ArbeidsgiverNotifikasjonKlientTest :
                         statusTekst = "mock statustekst",
                         nyLenke = "mock nyLenke",
                         tidspunkt = "mock tidspunkt",
+                        hardDeleteOm = 2.days,
                     )
                 }
             }
@@ -130,6 +131,7 @@ class ArbeidsgiverNotifikasjonKlientTest :
                         statusTekst = "mock statustekst",
                         nyLenke = "mock nyLenke",
                         tidspunkt = "mock tidspunkt",
+                        hardDeleteOm = 2.days,
                     )
                 }
             }
@@ -151,6 +153,7 @@ class ArbeidsgiverNotifikasjonKlientTest :
                         statusTekst = "mock statustekst",
                         nyLenke = "mock nyLenke",
                         tidspunkt = "mock tidspunkt",
+                        hardDeleteOm = 2.days,
                     )
                 }
             }


### PR DESCRIPTION
Vi ønsker å senke levetiden for inntektsmeldingssaker som viser seg å være unyttige. Vi vil ikke slette dem fordi arbeidsgiver skal få tid til å se notifikasjonen og gå inn på saken for å oppdage at Nav ikke lenger trenger inntektsmeldingen.